### PR TITLE
Fix highlight misalignment on drag

### DIFF
--- a/Assets/Scripts/Piece/DragHandler.cs
+++ b/Assets/Scripts/Piece/DragHandler.cs
@@ -19,6 +19,8 @@ public class DragHandler : MonoBehaviour,
     // 追加：直前にハイライトしていたセル
     private Vector2Int _lastHighlightOrigin;
     private bool _hasLastHighlight = false;
+    // ドラッグ開始位置からピース左下までのオフセット
+    private Vector2 _dragOffset;
 
     void Awake()
     {
@@ -48,6 +50,21 @@ public class DragHandler : MonoBehaviour,
         float scale = gridSize / handSize;
         transform.localScale = _originalScale * scale;
 
+        // 左下までのオフセットを計算
+        int maxX = int.MinValue;
+        int maxY = int.MinValue;
+        foreach (var c in _pieceUI.data.cells)
+        {
+            if (c.x > maxX) maxX = c.x;
+            if (c.y > maxY) maxY = c.y;
+        }
+        Vector2 pivotScreen = RectTransformUtility.WorldToScreenPoint(
+            eventData.pressEventCamera, _rect.position);
+        Vector2 bottomLeft = pivotScreen + new Vector2(
+            -_rect.pivot.x * (maxX + 1) * gridSize,
+            -_rect.pivot.y * (maxY + 1) * gridSize);
+        _dragOffset = eventData.position - bottomLeft;
+
         // 最初のハイライト表示
         UpdateHighlight(eventData);
     }
@@ -73,7 +90,9 @@ public class DragHandler : MonoBehaviour,
         // グリッド上のどのセルが起点かを取得
         Vector2Int origin;
         float cellW, cellH;
-        bool ok = GetGridOrigin(eventData, out origin, out cellW, out cellH);
+        Vector2 bottomLeft = eventData.position - _dragOffset;
+        bool ok = GetGridOrigin(bottomLeft, eventData.pressEventCamera,
+                               out origin, out cellW, out cellH);
 
         if (ok)
         {
@@ -147,7 +166,9 @@ public class DragHandler : MonoBehaviour,
 
         float cellW, cellH;
         Vector2Int origin;
-        bool ok = GetGridOrigin(eventData, out origin, out cellW, out cellH);
+        Vector2 bottomLeft = eventData.position - _dragOffset;
+        bool ok = GetGridOrigin(bottomLeft, eventData.pressEventCamera,
+                                out origin, out cellW, out cellH);
 
         // ヒステリシス(縦方向)…
         if (_hasLastHighlight
@@ -170,12 +191,12 @@ public class DragHandler : MonoBehaviour,
     }
 
     /// スクリーン座標 → セル原点を求め、配置可否を返す
-    private bool GetGridOrigin(PointerEventData eventData,
+    private bool GetGridOrigin(Vector2 bottomLeftScreen,
+                               Camera cam,
                                out Vector2Int origin,
                                out float cellW,
                                out float cellH)
     {
-        /*
         // GridManager とその RectTransform を取得
         var grid = GameManager.Instance.gridManager;
         var rtGrid = grid.GetComponent<RectTransform>();
@@ -184,8 +205,8 @@ public class DragHandler : MonoBehaviour,
         Vector2 localPoint;
         RectTransformUtility.ScreenPointToLocalPointInRectangle(
             rtGrid,
-            eventData.position,
-            eventData.pressEventCamera,
+            bottomLeftScreen,
+            cam,
             out localPoint
         );
 
@@ -200,8 +221,6 @@ public class DragHandler : MonoBehaviour,
             localPoint.y < 0f ||
             localPoint.y > rtGrid.rect.height)
         {
-
-            // 盤面外なので置けない
             origin = Vector2Int.zero;
             cellW = cellH = 0;
             return false;
@@ -211,46 +230,7 @@ public class DragHandler : MonoBehaviour,
         cellW = grid.CellSize;
         cellH = cellW;
 
-        // ④ 最寄りのセル座標に丸めて Clamp
-        int ox = Mathf.Clamp(
-            Mathf.RoundToInt(localPoint.x / cellW),
-            0, GridManager.Width - 1
-        );
-        int oy = Mathf.Clamp(
-            Mathf.RoundToInt(localPoint.y / cellH),
-            0, GridManager.Height - 1
-        );
-        origin = new Vector2Int(ox, oy);
-
-        // ⑤ その位置にピースを置けるか判定して返す
-        return grid.CanPlace(_pieceUI.data.cells, origin);
-    }
-    */
-
-        // GridManager とその RectTransform を取得
-        var grid = GameManager.Instance.gridManager;
-        var rtGrid = grid.GetComponent<RectTransform>();
-
-        // ① スクリーン座標 → ローカル座標（中心が (0,0)）
-        Vector2 localPoint;
-        RectTransformUtility.ScreenPointToLocalPointInRectangle(
-            rtGrid,
-            eventData.position,
-            eventData.pressEventCamera,
-            out localPoint
-        );
-
-        // ② 中心基準 → 左下原点に変換
-        float halfW = rtGrid.rect.width * 0.5f;
-        float halfH = rtGrid.rect.height * 0.5f;
-        localPoint += new Vector2(halfW, halfH);
-
-        // ③ セルサイズ (正方形) を取得
-        cellW = grid.CellSize;
-        cellH = cellW;
-
         // ④ 座標をセル単位に変換（0 から Width-1 / Height-1 の範囲内に丸め込む）
-        //    ただし、切り替え閾値を 0.5 → 0.3 に下げて手前優先に。
         float rawX = localPoint.x / cellW;
         float rawY = localPoint.y / cellH;
 


### PR DESCRIPTION
## Summary
- compute offset from pointer to piece origin on drag start
- use the offset when determining highlight position to keep it aligned with the dragged piece

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6852708ceb3483299de255be1bb6e0e1