### PR TITLE
Fix placement detection on grid edges

### DIFF
--- a/Assets/Scripts/Piece/DragHandler.cs
+++ b/Assets/Scripts/Piece/DragHandler.cs
@@ -234,7 +234,7 @@ public class DragHandler : MonoBehaviour,
         float rawX = localPoint.x / cellW;
         float rawY = localPoint.y / cellH;
 
-        const float switchThreshold = 0f; // ← ここを調整すると判定を手前／奥にシフトできます
+        const float switchThreshold = 0.5f; // ← ここを調整すると判定を手前／奥にシフトできます
 
         int fx = Mathf.FloorToInt(rawX);
         float fractX = rawX - fx;


### PR DESCRIPTION
## Summary
- adjust switch threshold in `DragHandler.GetGridOrigin` so pieces can be placed on the left and bottom edges

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6852790134d48329aae5b913ce331e80