### PR TITLE
Fix weighted random piece selection

### DIFF
--- a/Assets/Scripts/Hand/HandManager.cs
+++ b/Assets/Scripts/Hand/HandManager.cs
@@ -85,8 +85,7 @@ public class HandManager : MonoBehaviour
         // 2) 乱数を引く [0, total)
         int r = Random.Range(0, total);
 
-            for (int x = GridManager.OffsetX; x < GridManager.OffsetX + GridManager.Width; x++)
-                for (int y = GridManager.OffsetY; y < GridManager.OffsetY + GridManager.Height; y++)
+        int sum = 0;
         foreach (var wp in _stageData.allowedPieces)
         {
             sum += Mathf.Max(wp.weight, 0);


### PR DESCRIPTION
## Summary
- ensure `sum` variable is defined in `HandManager.PickWeightedRandomPiece`
- remove stray loops from method

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853c0bce9648329902281d8ff5f2e2b