### PR TITLE
Fix grid pivot for BoardHighlighter

### DIFF
--- a/Assets/Scripts/Core/UIInitializer.cs
+++ b/Assets/Scripts/Core/UIInitializer.cs
@@ -7,10 +7,11 @@ public class UIInitializer : MonoBehaviour
 {
     void Awake()
     {
-        Debug.Log("‰Šú‰»ˆ—ÀsI");
+            // Pivot must remain centered for BoardHighlighter calculations
+            rtGrid.pivot = new Vector2(0.5f, 0.5f);
 
 
-        // ¡ Canvas ‚Ì Scale ‚ğ 1,1,1 ‚É–ß‚·
+        // â–  Canvas ã® Scale ã‚’ 1,1,1 ã«æˆ»ã™
         var canvas = Object.FindAnyObjectByType<Canvas>();
         if (canvas != null)
         {
@@ -18,7 +19,7 @@ public class UIInitializer : MonoBehaviour
             rtCanvas.localScale = Vector3.one;
         }
 
-        // ¡ GridManager ‚Ì RectTransform ‚ğƒŠƒZƒbƒg
+        // â–  GridManager ã® RectTransform ã‚’ãƒªã‚»ãƒƒãƒˆ
         var gridGO = GameObject.Find("Canvas/GridManager");
         if (gridGO != null)
         {


### PR DESCRIPTION
## Summary
- keep GridManager pivot at `(0.5, 0.5)` so BoardHighlighter stays aligned

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853ccd88e3c8329bc8b2023974d7ca8