### PR TITLE
Fix drag prefab sizing

### DIFF
--- a/Assets/Scripts/Piece/DragHandler.cs
+++ b/Assets/Scripts/Piece/DragHandler.cs
@@ -80,19 +80,18 @@ public class DragHandler : MonoBehaviour,
         transform.localScale = _originalScale * scale;
 
         // 左下までのオフセットを計算
-        int maxX = int.MinValue;
-        int maxY = int.MinValue;
-        foreach (var c in _pieceUI.data.cells)
-        {
-            if (c.x > maxX) maxX = c.x;
-            if (c.y > maxY) maxY = c.y;
-        }
-        Vector2 pivotScreen = RectTransformUtility.WorldToScreenPoint(
-            eventData.pressEventCamera, _rect.position);
-        Vector2 bottomLeft = pivotScreen + new Vector2(
-            -_rect.pivot.x * (maxX + 1) * gridSize,
-            -_rect.pivot.y * (maxY + 1) * gridSize);
-        _dragOffset = eventData.position - bottomLeft;
+        //   PieceUI の RectTransform はピース実サイズより大きいため
+        //   実際の Rect サイズを考慮してスクリーン座標を求める
+
+        // Rect の左下ワールド座標を取得
+        Vector3 worldBottomLeft = _rect.TransformPoint(new Vector3(
+            -_rect.pivot.x * _rect.rect.width,
+            -_rect.pivot.y * _rect.rect.height,
+            0f));
+        Vector2 bottomLeftScreen = RectTransformUtility.WorldToScreenPoint(
+            eventData.pressEventCamera, worldBottomLeft);
+
+        _dragOffset = eventData.position - bottomLeftScreen;
 
         // 最初のハイライト表示
         UpdateHighlight(eventData);

--- a/Assets/Scripts/Piece/PieceUI.cs
+++ b/Assets/Scripts/Piece/PieceUI.cs
@@ -1,4 +1,3 @@
-// Assets/Scripts/Hand/PieceUI.cs
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -7,33 +6,36 @@ public class PieceUI : MonoBehaviour
 {
     [HideInInspector] public PieceData data;
 
-    // 手札内で の１セルサイズ（お好みで調整）
     public const float ThumbCellSize = 50f;
 
-    // （必要であれば）インスタンス用の読み取り専用プロパティも用意
     public float CellSizeInHand => ThumbCellSize;
 
     public void Init(PieceData d)
     {
         data = d;
 
-            // 既存 Image は透明化してレイキャストだけ生かす
-        var oldImg = GetComponent<Image>();
-            if (oldImg != null)
-                {
-            oldImg.sprite = null;                 // 表示しない
-            oldImg.color = new Color(1, 1, 1, 0);    // 完全透明
-            oldImg.raycastTarget = true;                 // イベントを受け取る
-                }
-            else
-                {
-                    // もし無ければ透明 Image を追加
-            oldImg = gameObject.AddComponent<Image>();
-            oldImg.color = new Color(1, 1, 1, 0);
-            oldImg.raycastTarget = true;
-                }
+        // ensure an Image component exists for raycast purposes
+        var imgRoot = GetComponent<Image>();
+        if (imgRoot == null)
+            imgRoot = gameObject.AddComponent<Image>();
+        imgRoot.sprite = null;
+        imgRoot.color = new Color(1, 1, 1, 0);
+        imgRoot.raycastTarget = true;
 
-        // 手札用のセルを描画
+        // calculate piece bounds to size the rect correctly
+        int maxX = int.MinValue;
+        int maxY = int.MinValue;
+        foreach (var c in data.cells)
+        {
+            if (c.x > maxX) maxX = c.x;
+            if (c.y > maxY) maxY = c.y;
+        }
+        var rtRoot = GetComponent<RectTransform>();
+        rtRoot.sizeDelta = new Vector2(
+            (maxX + 1) * ThumbCellSize,
+            (maxY + 1) * ThumbCellSize);
+
+        // spawn child blocks
         foreach (var c in data.cells)
         {
             var go = new GameObject("ThumbBlock", typeof(RectTransform));
@@ -47,15 +49,10 @@ public class PieceUI : MonoBehaviour
             var rt = go.GetComponent<RectTransform>();
             rt.pivot = Vector2.zero;
             rt.sizeDelta = Vector2.one * ThumbCellSize;
-
-            // 縦固定で左下基準なら、セル座標をそのまま使えます
             rt.anchoredPosition = new Vector2(
                 c.x * ThumbCellSize,
                 c.y * ThumbCellSize
             );
         }
-
-        // 手札同士が重ならないよう全体を中央寄せにしたい場合は、
-        // RectTransform の anchoredPosition を調整してください。
     }
 }


### PR DESCRIPTION
## Summary
- compute PieceUI RectTransform size from piece cells
- keep block children spawn logic the same

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6853d183b90483298d3ed879f86582df