### PR TITLE
Fix pivot for PieceUI

### DIFF
--- a/Assets/Scripts/Piece/DragHandler.cs
+++ b/Assets/Scripts/Piece/DragHandler.cs
@@ -145,7 +145,7 @@ public class DragHandler : MonoBehaviour,
 
                 // スケール／ピボットは最後に戻す
                 transform.localScale = _originalScale;
-                _rect.pivot = new Vector2(0, 0.5f);
+                _rect.pivot = Vector2.zero; // restore bottom-left pivot
                 return;
             }
         }
@@ -160,7 +160,7 @@ public class DragHandler : MonoBehaviour,
         transform.SetParent(_originalParent, true);
         _rect.anchoredPosition = _originalAnchoredPos;
         transform.localScale = _originalScale;
-        _rect.pivot = new Vector2(0, 0.5f);
+        _rect.pivot = Vector2.zero; // restore bottom-left pivot
     }
 
 

--- a/Assets/Scripts/Piece/PieceUI.cs
+++ b/Assets/Scripts/Piece/PieceUI.cs
@@ -31,6 +31,7 @@ public class PieceUI : MonoBehaviour
             if (c.y > maxY) maxY = c.y;
         }
         var rtRoot = GetComponent<RectTransform>();
+        rtRoot.pivot = Vector2.zero; // pivot at lower-left so child cells align
         rtRoot.sizeDelta = new Vector2(
             (maxX + 1) * ThumbCellSize,
             (maxY + 1) * ThumbCellSize);


### PR DESCRIPTION
## Summary
- adjust the root RectTransform pivot to the lower-left when creating a piece
- keep the pivot consistent when finishing a drag operation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854d2341d7c8329b610141b41ec9ba5