### PR TITLE
Simplify grid coordinates

### DIFF
--- a/Assets/Scripts/Core/GridManager.cs
+++ b/Assets/Scripts/Core/GridManager.cs
@@ -11,8 +11,6 @@ public class GridManager : MonoBehaviour
 {
     public const int Width = 10;  // 列数
     public const int Height = 16; // 行数
-    public const int OffsetX = 2; // 表示上のXオフセット
-    public const int OffsetY = 1; // 表示上のYオフセット
 
     /// <summary>累計開放セル数</summary>
     public int OpenedBackgroundCells { get; private set; }
@@ -142,8 +140,8 @@ public class GridManager : MonoBehaviour
     {
         foreach (var c in cells)
         {
-            int x = origin.x - OffsetX + c.x;
-            int y = origin.y - OffsetY + c.y;
+            int x = origin.x + c.x;
+            int y = origin.y + c.y;
             if (x < 0 || x >= Width || y < 0 || y >= Height) return false;
             if (_grid[x, y] != 0) return false;
         }
@@ -156,16 +154,16 @@ public class GridManager : MonoBehaviour
         // 論理グリッド
         foreach (var c in data.cells)
         {
-            int x = origin.x - OffsetX + c.x;
-            int y = origin.y - OffsetY + c.y;
+            int x = origin.x + c.x;
+            int y = origin.y + c.y;
             if (x < 0 || x >= Width || y < 0 || y >= Height) continue;
             _grid[x, y] = 1;
         }
         // 見た目ブロック
         foreach (var c in data.cells)
         {
-            int x = origin.x - OffsetX + c.x;
-            int y = origin.y - OffsetY + c.y;
+            int x = origin.x + c.x;
+            int y = origin.y + c.y;
             if (x < 0 || x >= Width || y < 0 || y >= Height) continue;
             var go = new GameObject("Block",
                                     typeof(RectTransform),

--- a/Assets/Scripts/Piece/DragHandler.cs
+++ b/Assets/Scripts/Piece/DragHandler.cs
@@ -290,8 +290,8 @@ public class DragHandler : MonoBehaviour,
         ox = Mathf.Clamp(ox, 0, GridManager.Width - 1);
         oy = Mathf.Clamp(oy, 0, GridManager.Height - 1);
 
-        origin = new Vector2Int(ox + GridManager.OffsetX,
-                                oy + GridManager.OffsetY);
+        // グリッド座標をそのまま返す
+        origin = new Vector2Int(ox, oy);
 
         // ⑤ その位置にピースを置けるか判定して返す
         return grid.CanPlace(_pieceUI.data.cells, origin);

--- a/Assets/Scripts/UI/BoardHighlighter.cs
+++ b/Assets/Scripts/UI/BoardHighlighter.cs
@@ -36,11 +36,11 @@ public class BoardHighlighter : MonoBehaviour
 
         Color col = ok ? okColor : ngColor;
         int index = 0;
-        // 盤面とのズレを補正するため、origin からグリッドのオフセットを差し引く
+        // origin はグリッド座標なのでそのまま扱う
         foreach (var c in cells)
         {
-            int x = origin.x - GridManager.OffsetX + c.x;
-            int y = origin.y - GridManager.OffsetY + c.y;
+            int x = origin.x + c.x;
+            int y = origin.y + c.y;
             if (x < 0 || x >= GridManager.Width || y < 0 || y >= GridManager.Height)
                 continue;
 


### PR DESCRIPTION
## Summary
- remove `OffsetX` and `OffsetY` constants from `GridManager`
- update placement logic to use unadjusted grid coordinates
- update drag handling and board highlighting accordingly

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6854e8d3bb1c8329b39ac1506dd410fe