### PR TITLE
Fix Canvas lookup order

### DIFF
--- a/Assets/Scripts/Core/UIInitializer.cs
+++ b/Assets/Scripts/Core/UIInitializer.cs
@@ -8,7 +8,10 @@ public class UIInitializer : MonoBehaviour
     void Awake()
     {
         // ■ Canvas の Scale を 1,1,1 に戻す
-        var canvas = Object.FindAnyObjectByType<Canvas>();
+        // Prefer the explicitly named root canvas, fall back to the first one found
+        var canvasGO = GameObject.Find("Canvas");
+        var canvas = canvasGO != null ? canvasGO.GetComponent<Canvas>() : null;
+        canvas ??= Object.FindAnyObjectByType<Canvas>();
         if (canvas != null)
         {
             var rtCanvas = canvas.GetComponent<RectTransform>();


### PR DESCRIPTION
## Summary
- search for a GameObject named `Canvas` before falling back to `FindAnyObjectByType<Canvas>`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854ef1b8cd08329aeede97a2065c7c0