### PR TITLE
Fix drag offset using canvas camera

### DIFF
--- a/Assets/Scripts/Piece/DragHandler.cs
+++ b/Assets/Scripts/Piece/DragHandler.cs
@@ -89,7 +89,7 @@ public class DragHandler : MonoBehaviour,
             -_rect.pivot.y * _rect.rect.height,
             0f));
         Vector2 bottomLeftScreen = RectTransformUtility.WorldToScreenPoint(
-            eventData.pressEventCamera, worldBottomLeft);
+            _canvas.worldCamera, worldBottomLeft);
 
         _dragOffset = eventData.position - bottomLeftScreen;
 
@@ -110,7 +110,7 @@ public class DragHandler : MonoBehaviour,
         RectTransformUtility.ScreenPointToLocalPointInRectangle(
             _canvas.GetComponent<RectTransform>(),
             bottomLeftScreen,
-            eventData.pressEventCamera,
+            _canvas.worldCamera,
             out localPoint);
         _rect.anchoredPosition = localPoint;
 
@@ -134,7 +134,7 @@ public class DragHandler : MonoBehaviour,
         Vector2Int origin;
         float cellW, cellH;
         Vector2 bottomLeft = eventData.position - _dragOffset;
-        bool ok = GetGridOrigin(bottomLeft, eventData.pressEventCamera,
+        bool ok = GetGridOrigin(bottomLeft, _canvas.worldCamera,
                                out origin, out cellW, out cellH);
 
         if (ok)
@@ -199,7 +199,7 @@ public class DragHandler : MonoBehaviour,
 
         // ① ドラッグ座標がグリッド Rect 内かチェック
         if (!RectTransformUtility.RectangleContainsScreenPoint(
-                rtGrid, eventData.position, eventData.pressEventCamera))
+                rtGrid, eventData.position, _canvas.worldCamera))
         {
             _hasLastHighlight = false;     // ヒステリシスもリセット
             _highlighter.Clear();          // 完全に消す
@@ -209,14 +209,14 @@ public class DragHandler : MonoBehaviour,
         // 以下これまでの処理…
         Vector2 localPoint;
         RectTransformUtility.ScreenPointToLocalPointInRectangle(
-            rtGrid, eventData.position, eventData.pressEventCamera, out localPoint);
+            rtGrid, eventData.position, _canvas.worldCamera, out localPoint);
         localPoint += new Vector2(rtGrid.rect.width * rtGrid.pivot.x,
                                   rtGrid.rect.height * rtGrid.pivot.y);
 
         float cellW, cellH;
         Vector2Int origin;
         Vector2 bottomLeft = eventData.position - _dragOffset;
-        bool ok = GetGridOrigin(bottomLeft, eventData.pressEventCamera,
+        bool ok = GetGridOrigin(bottomLeft, _canvas.worldCamera,
                                 out origin, out cellW, out cellH);
 
         // ヒステリシス(縦方向)…


### PR DESCRIPTION
## Summary
- correct DragHandler coordinate conversions by using the Canvas camera

## Testing
- `Running tests (none present)`

------
https://chatgpt.com/codex/tasks/task_e_6854ff7c7ee88329801f4436fb4c93bd