### PR TITLE
Rename inGrid variable to canPlace

### DIFF
--- a/Assets/Scripts/Piece/DragHandler.cs
+++ b/Assets/Scripts/Piece/DragHandler.cs
@@ -111,10 +111,10 @@ public class DragHandler : MonoBehaviour,
         Vector2 bottomLeftScreen = eventData.position - _dragOffset;
         Vector2Int dummyOrigin;
         float cellW, cellH;
-        bool inGrid = GetGridOrigin(bottomLeftScreen, _canvas.worldCamera,
-                                    out dummyOrigin, out cellW, out cellH);
+        bool canPlace = GetGridOrigin(bottomLeftScreen, _canvas.worldCamera,
+                                      out dummyOrigin, out cellW, out cellH);
 
-        if (_hasLastHighlight && (inGrid || cellW > 0f))
+        if (_hasLastHighlight && (canPlace || cellW > 0f))
         {
             var grid = GameManager.Instance.gridManager;
             var rtGrid = grid.GetComponent<RectTransform>();
@@ -159,7 +159,7 @@ public class DragHandler : MonoBehaviour,
 
         if (ok)
         {
-            // グリッド内タッチ＋
+            // 配置可能な位置なら
             // 全セル配置可能か（範囲外セルも含めて）チェック
             if (GameManager.Instance.gridManager
                     .CanPlace(_pieceUI.data.cells, origin))


### PR DESCRIPTION
## Summary
- update DragHandler to use `canPlace` instead of `inGrid`
- clarify comment to match the new meaning

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68550a03271c8329ad59004876209272