### PR TITLE
Remove unused canvas scale script

### DIFF
--- a/Assets/Scripts/Core/ForceCanvasScaleOne.cs
+++ b/Assets/Scripts/Core/ForceCanvasScaleOne.cs
@@ -1,6 +1,0 @@
-using UnityEngine;
-
-public class ForceCanvasScaleOne
-{
-    
-}

--- a/Assets/Scripts/Core/ForceCanvasScaleOne.cs.meta
+++ b/Assets/Scripts/Core/ForceCanvasScaleOne.cs.meta
@@ -1,2 +1,0 @@
-fileFormatVersion: 2
-guid: 7daed49889ce4ef4b9a2bbca24a2fa3c


### PR DESCRIPTION
## Summary
- remove empty ForceCanvasScaleOne script
- Canvas scale is already enforced in `UIInitializer`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68550a04585883299f2d2561c61a8ebb