### PR TITLE
Ensure PieceUI uses centered anchors

### DIFF
--- a/Assets/Scripts/Piece/PieceUI.cs
+++ b/Assets/Scripts/Piece/PieceUI.cs
@@ -31,6 +31,9 @@ public class PieceUI : MonoBehaviour
             if (c.y > maxY) maxY = c.y;
         }
         var rtRoot = GetComponent<RectTransform>();
+        // anchor to canvas center so DragHandler coordinates match
+        rtRoot.anchorMin = rtRoot.anchorMax = new Vector2(0.5f, 0.5f);
+        rtRoot.anchoredPosition = Vector2.zero;
         rtRoot.pivot = Vector2.zero; // pivot at lower-left so child cells align
         rtRoot.sizeDelta = new Vector2(
             (maxX + 1) * ThumbCellSize,


### PR DESCRIPTION
## Summary
- fix mismatched anchoring in `PieceUI.Init`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68550c16a9fc832990d8992b315b6218