### PR TITLE
Reset anchors when drag begins

### DIFF
--- a/Assets/Scripts/Piece/DragHandler.cs
+++ b/Assets/Scripts/Piece/DragHandler.cs
@@ -61,6 +61,10 @@ public class DragHandler : MonoBehaviour,
         transform.SetParent(_canvas.transform, true);
         transform.SetAsLastSibling();
 
+        // レイアウトグループから外れると Anchor が (0,1) に残るので中央に戻す
+        _rect.anchorMin = _rect.anchorMax = new Vector2(0.5f, 0.5f);
+        _rect.anchoredPosition = Vector2.zero;
+
         // グリッド上の「1セル辺長」を取得
         float gridSize = GameManager.Instance.gridManager.CellSize;
 

--- a/Assets/Scripts/Piece/PieceUI.cs
+++ b/Assets/Scripts/Piece/PieceUI.cs
@@ -31,6 +31,9 @@ public class PieceUI : MonoBehaviour
             if (c.y > maxY) maxY = c.y;
         }
         var rtRoot = GetComponent<RectTransform>();
+        // anchor to canvas center so DragHandler coordinates match
+        rtRoot.anchorMin = rtRoot.anchorMax = new Vector2(0.5f, 0.5f);
+        rtRoot.anchoredPosition = Vector2.zero;
         rtRoot.pivot = Vector2.zero; // pivot at lower-left so child cells align
         rtRoot.sizeDelta = new Vector2(
             (maxX + 1) * ThumbCellSize,


### PR DESCRIPTION
## Summary
- ensure drag pieces reset anchors after leaving layout group

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68550c16a9fc832990d8992b315b6218